### PR TITLE
Fix handling of spaces in problem folder names

### DIFF
--- a/CodeJam/createFolders.bash
+++ b/CodeJam/createFolders.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TARGET_DIR="$1"
-PROBLEM_FOLDERS=(${@:2})
+PROBLEM_FOLDERS=("${@:2}")
 
 IFS=$'\n'
 DIR="$( cd "$( dirname $0 )" && pwd -P )"


### PR DESCRIPTION
Prevent decomposition of "folder name" into two folders